### PR TITLE
Add 20m threshold

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -46,7 +46,8 @@ jobs:
           python3 scripts/plot_route_from_waypoints.py \
             --input src/fell/allermuir-hill-race/allermuir-hill-race-waypoints.gpx \
             --gpx-output src/fell/allermuir-hill-race/allermuir-hill-race.gpx \
-            --png-output docs/assets/images/allermuir-hill-race.png
+            --png-output docs/assets/images/allermuir-hill-race.png \
+            --snap-threshold 20.0
 
       - name: Generate GPX files
         run: python3 scripts/generate_gpx_files.py


### PR DESCRIPTION
This pull request updates the `jekyll-gh-pages` workflow to enhance the waypoint plotting script by adding a new parameter for improved control over route generation.

Enhancements to waypoint plotting:

* [`.github/workflows/jekyll-gh-pages.yml`](diffhunk://#diff-36a7fe6e9af1fc515ab07c70bee1dd529453c776db13abf7f5c6b2b3b34c4be3L49-R50): Added the `--snap-threshold` parameter with a value of `20.0` to the `plot_route_from_waypoints.py` script, allowing for finer control over waypoint snapping during route plotting.